### PR TITLE
Use https to install elementary tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is a fork of the [original elementary-tweaks](https://launchpad.
 ## How to install
 
     # Install i-hate-farms repository (not necessary if already done)
-    curl -sL  http://i-hate-farms.github.io/spores/install | sudo bash - 
+    curl -sL  https://i-hate-farms.github.io/spores/install | sudo bash - 
     sudo apt-get install elementary-tweaks
     
 ## Features


### PR DESCRIPTION
The server also works with https, so we should use it instead.
This was tested in a vm and it works of course.
