### PR TITLE
Added Follow last tab option to settings

### DIFF
--- a/src/Grids/TerminalGrid.vala
+++ b/src/Grids/TerminalGrid.vala
@@ -207,6 +207,18 @@ namespace ElementaryTweaks {
                     );
             this.add (natural_copy_paste_switch);
             
+            var follow_last_tab = new TweakWidget.with_switch (
+                        _("Follow last tab:"),
+                        _("If the user opens a new tab either take the current workdirectory of the previous tab or the default one."),
+                        null,
+                        (() => { return TerminalSettings.get_default ().follow-last-tab; }), // get
+                        ((val) => {
+                                TerminalSettings.get_default ().follow-last-tab = val;
+                            }), // set
+                        (() => { TerminalSettings.get_default ().schema.reset ("follow-last-tab"); }) // reset
+                    );
+            this.add (follow_last_tab);
+            
             var cursor_map = new Gee.HashMap<string, string> ();
             cursor_map.set ("Block", _("Block"));
             cursor_map.set ("I-Beam", _("I-Beam"));

--- a/src/Grids/TerminalGrid.vala
+++ b/src/Grids/TerminalGrid.vala
@@ -211,9 +211,9 @@ namespace ElementaryTweaks {
                         _("Follow last tab:"),
                         _("If the user opens a new tab either take the current workdirectory of the previous tab or the default one."),
                         null,
-                        (() => { return TerminalSettings.get_default ().follow-last-tab; }), // get
+                        (() => { return TerminalSettings.get_default ().follow_last_tab; }), // get
                         ((val) => {
-                                TerminalSettings.get_default ().follow-last-tab = val;
+                                TerminalSettings.get_default ().follow_last_tab = val;
                             }), // set
                         (() => { TerminalSettings.get_default ().schema.reset ("follow-last-tab"); }) // reset
                     );

--- a/src/Settings/TerminalSettings.vala
+++ b/src/Settings/TerminalSettings.vala
@@ -29,6 +29,7 @@ namespace ElementaryTweaks {
         public int scrollback_lines { get; set; }
         public bool unsafe_paste_alert { get; set; }
         public bool natural_copy_paste { get; set; }
+        public bool follow_last_tab { get; set; }
         public string cursor_shape { get; set; }
                 
         static TerminalSettings? instance = null;


### PR DESCRIPTION
That is one of the things I immediately want to change about a terminal, so it would be nice to have a setting for that.

I have not tested it, but the way I changed it on my machine is `gsettings set org.pantheon.terminal.settings follow-last-tab true` so based on the other code I assumed that is what's necessary.
